### PR TITLE
Remove double button press when C is pressed.

### DIFF
--- a/guncon2.c
+++ b/guncon2.c
@@ -115,7 +115,7 @@ static void guncon2_usb_irq(struct urb *urb) {
 
         // main buttons
         input_report_key(guncon2->input_device, BTN_LEFT, buttons & GUNCON2_TRIGGER);
-        input_report_key(guncon2->input_device, BTN_RIGHT, buttons & GUNCON2_BTN_A || buttons & GUNCON2_BTN_C);
+        input_report_key(guncon2->input_device, BTN_RIGHT, buttons & GUNCON2_BTN_A);
         input_report_key(guncon2->input_device, BTN_MIDDLE, buttons & GUNCON2_BTN_B);
         input_report_key(guncon2->input_device, BTN_A, buttons & GUNCON2_BTN_A);
         input_report_key(guncon2->input_device, BTN_B, buttons & GUNCON2_BTN_B);


### PR DESCRIPTION
Why on earth would A be pressed at the same time as C is just a bad decision. This fixes that.